### PR TITLE
Make modules discoverable

### DIFF
--- a/python_src/dead_instrumenter/__init__.py
+++ b/python_src/dead_instrumenter/__init__.py
@@ -1,0 +1,26 @@
+from .instrumenter import (
+    InstrumentedProgram,
+    get_instrumenter,
+    annotate_with_static,
+)
+
+from diopter.compiler import (
+    CompileError,
+    ClangTool,
+    ClangToolMode,
+    SourceProgram,
+    CompilerExe,
+    CompilationSetting,
+)
+
+__all__ = [
+    "InstrumentedProgram",
+    "get_instrumenter",
+    "annotate_with_static",
+    "CompileError",
+    "ClangTool",
+    "ClangToolMode",
+    "SourceProgram",
+    "CompilerExe",
+    "CompilationSetting",
+]


### PR DESCRIPTION
Currently, you can only use dead_instrumenter when you know that there is `from dead_instrumenter.instrumenter import X`.

This commit makes the functionality discoverable. For example, you can now call `dead_instrumenter.get_instrumenter()`.
