### PR TITLE
InstrumenterProgram.find_dead_and_alive_markers

### DIFF
--- a/python_src/dead_instrumenter/instrumenter.py
+++ b/python_src/dead_instrumenter/instrumenter.py
@@ -165,6 +165,12 @@ def find_alive_markers_impl(asm: str) -> tuple[Marker, ...]:
 
 
 @dataclass(frozen=True, kw_only=True)
+class MarkerStatus:
+    dead_markers: tuple[Marker, ...]
+    alive_markers: tuple[Marker, ...]
+
+
+@dataclass(frozen=True, kw_only=True)
 class InstrumentedProgram(SourceProgram):
     dce_markers: tuple[DCEMarker, ...] = tuple()
     vr_markers: tuple[VRMarker, ...] = tuple()
@@ -256,6 +262,22 @@ class InstrumentedProgram(SourceProgram):
             self.find_alive_markers(compilation_setting)
         )
         return tuple(dead_markers)
+
+    def find_dead_and_alive_markers(
+        self, compilation_setting: CompilationSetting
+    ) -> MarkerStatus:
+        """Compiles the program to ASM with `compilation_setting` and finds
+        dead and alive markers, i.e., markers that have been eliminated or not
+
+        Returns:
+            MarkerStatus:
+                The dead and alive markers for the given compilation setting.
+        """
+        alive_markers = self.find_alive_markers(compilation_setting)
+        dead_markers = set(self.all_markers()) - set(alive_markers)
+        return MarkerStatus(
+            dead_markers=tuple(dead_markers), alive_markers=alive_markers
+        )
 
     @staticmethod
     def __make_disable_macro(marker: Marker) -> str:

--- a/python_src/test/dce_instrumenter_test.py
+++ b/python_src/test/dce_instrumenter_test.py
@@ -29,6 +29,12 @@ def test_instrumentation() -> None:
     )
     assert set() == set(iprogram.find_dead_markers(gcc))
 
+    marker_status = iprogram.find_dead_and_alive_markers(gcc)
+    assert set() == set(marker_status.dead_markers)
+    assert set((DCEMarker("DCEMarker0_"), DCEMarker("DCEMarker1_"))) == set(
+        marker_status.alive_markers
+    )
+
 
 def test_disable_markers() -> None:
     iprogram = instrument_program(


### PR DESCRIPTION
Add method to return both the alive and dead markers. Using the existict find_alive and find_dead methods needs to compilations (instead of one)